### PR TITLE
make zr deal with symlinked roots

### DIFF
--- a/zr/Cargo.toml
+++ b/zr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zr"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
zr wouldn't find any snapshots if the requested path contained a symlink